### PR TITLE
[DEVELOPER-295] - Fix kitchensink links on Get Started.

### DIFF
--- a/_layouts/get-started-overview.html.slim
+++ b/_layouts/get-started-overview.html.slim
@@ -27,8 +27,8 @@ layout: base
     .large-7.columns
       .get-started-content
         a.button.get-started-quickstart(href="../quickstarts/eap/helloworld") Hello World
-        a.button.get-started-quickstart(href="../quickstarts/eap/kitchensink-html5-mobile") Kitchensink (JQuery Mobile)
-        a.button.get-started-quickstart(href="../quickstarts/eap/kitchensink-angularjs") Kitchensink (AngularJS)
+        a.button.get-started-quickstart(href="../quickstarts/wfk/kitchensink-html5-mobile") Kitchensink (JQuery Mobile)
+        a.button.get-started-quickstart(href="../quickstarts/wfk/kitchensink-angularjs") Kitchensink (AngularJS)
 
 .row
   h2.divider Looking to learn more about JBoss?


### PR DESCRIPTION
The link pointed to the wrong location. Had to change 'eap' to 'wfk'. 
