### PR TITLE
Update jboss-developer.json

### DIFF
--- a/_dcp/data/provider/jboss-developer.json
+++ b/_dcp/data/provider/jboss-developer.json
@@ -7,7 +7,7 @@
   "type": {
     "jbossdeveloper_quickstart": {
       "description":"Readmes from JBoss Developer",
-      "sys_type":"jbossdeveloper_quickstart_readme",
+      "sys_type":"jbossdeveloper_quickstart",
       "sys_content_content-type" : "text/html",
       "input_preprocessors": [
         {
@@ -47,7 +47,7 @@
       ],
       "index": {
         "name":"data_jbossdeveloper_quickstart",
-        "type":"jbossdeveloper_quickstart_readme"
+        "type":"jbossdeveloper_quickstart"
       }
     },
     "jbossdeveloper_bom": {


### PR DESCRIPTION
Remove `_readme` suffixes from `jbossdeveloper_quickstart` content type. It was used for:
- Elasticsearch index type (which means it did not match the mapping definition)
- `sys_type` (I removed it to make it consistent with other `sys_type`s defined in this file)
