### PR TITLE
Add HTML Strip preprocessor to jbossdeveloper_example type

### DIFF
--- a/_dcp/data/provider/jboss-developer.json
+++ b/_dcp/data/provider/jboss-developer.json
@@ -108,6 +108,14 @@
       "sys_content_content-type":"text/html",
       "input_preprocessors": [
         {
+          "name" : "Strip HTML tags in sys_content to plain text in sys_content_plaintext",
+          "class" : "org.jboss.elasticsearch.tools.content.StripHtmlPreprocessor",
+          "settings" : {
+            "source_field"  : "sys_content",
+            "target_field"  : "sys_content_plaintext"
+          }
+        },
+        {
           "name"     : "Contributors mapper",
           "class"    : "org.jboss.elasticsearch.tools.content.ESLookupValuePreprocessor",
           "settings" : {


### PR DESCRIPTION
Strip HTML tags in `sys_content` to plain text in `sys_content_plaintext`. This will allow better out-of-the-box full-text search experience when using Searchisko search API.
