### PR TITLE
Products Page fixes for DEVELOPER-381 and DEVELOPER-382

### DIFF
--- a/_layouts/product-index.html.slim
+++ b/_layouts/product-index.html.slim
@@ -7,55 +7,64 @@ layout: technology-base
   .development-tool-category
     h2.divider Application Platforms
     .development-tool
-      .product-logos-enterprise-app-platform 
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/enterprise-app-platform.png')}"
       = page._eap
       a.button(href="eap/overview") Learn More
 
     .development-tool
-      .product-logos-web-server
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/web-server.png')}"
+
       = page._web_server
       a.button(href="webserver/overview") Learn More
 
     .development-tool
-      .product-logos-data-grid
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/data-grid.png')}"
+
       = page._data_grid
       a.button(href="datagrid/overview") Learn More
 
     .development-tool
-      .product-logos-portal
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/portal.png')}"
+
       = page._portal
       a.button(href="portal/overview") Learn More
 
   .development-tool-category
     h2.divider Integration
     .development-tool
-      .product-logos-fsw.png
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/fsw.png')}"
+
       = page._fuse_service_works
       a.button(href="fsw/overview") Learn More
 
     .development-tool
-      .product-logos-data-virtualization
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/data-virtualization.png')}"
+
       = page._data_virtualization
       a.button(href="datavirt/overview") Learn More
 
     .development-tool
-      .product-logos-fuse
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/fuse.png')}"
+
       = page._fuse
       a.button(href="fuse/overview") Learn More
 
     .development-tool
-      .product-logos-a-mq
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/a-mq.png')}"
+
       = page._a_mq
       a.button(href="amq/overview") Learn More
   .development-tool-category
     h2.divider Automation
     .development-tool
-      .product-logos-brms.png
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/brms.png')}"
+
       = page._brms
       a.button(href="brms/overview") Learn More
 
     .development-tool
-      .product-logos-bpm-suite.png
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/bpm-suite.png')}"
+
       = page._bpm_suite
       a.button(href="bpmsuite/overview") Learn More
 
@@ -63,7 +72,8 @@ layout: technology-base
   .development-tool-category
     h2.divider Development Tools
     .development-tool
-      .product-logos-developer-studio
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/developer-studio.png')}"
+
       = page._developer_studio
       a.button(href="devstudio/overview") Learn More
 
@@ -77,7 +87,8 @@ layout: technology-base
   .development-tool-category
     h2.divider Management
     .development-tool
-      .product-logos-operationsnetwork.png
+      img src="#{cdn( site.base_url + '/images/branding/product-logos/operationsnetwork.png')}"
+
       = page._operations_network
       a.button(href="operationsnetwork/overview") Learn More
 

--- a/javascripts/scripts.js
+++ b/javascripts/scripts.js
@@ -237,6 +237,12 @@ app.init = function() {
   var devTools = $('.development-tool');
   if(devTools.length) {
     app.developmentTools();
+
+    // run again on window resize
+    $(window).on('scroll',function() {
+      app.developmentTools();
+    });
+
   }
   
   /*
@@ -545,6 +551,25 @@ app.sideNav = function() {
     $('.side-nav').toggleClass('side-nav-open');
   });
 
+};
+
+/*
+   Development Tools even bottoms
+ */
+
+app.developmentTools = function(){
+  $('.development-tool-category').each(function() {
+   var items = $(this).find('.development-tool:even');
+   $(items).each(function(i,el) {
+     var that = $(this);
+     that.height('auto');
+     that.next().height('auto');
+
+     var max = Math.max(that.outerHeight(), that.next().outerHeight()) + 50; // account for the absolute learn more button
+     that.css('height',max);
+     that.next().css('height',max);
+   });
+  });
 };
 
 /*

--- a/stylesheets/_mobile.scss
+++ b/stylesheets/_mobile.scss
@@ -30,6 +30,11 @@
       margin:0 !important;
       margin-bottom: 20px !important;
       height:auto !important; // overwrite the inline JS styles
+      min-height:none;
+      a.button {
+        position: relative;
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -656,9 +656,8 @@ i[class*=fa].invert {
   background:$grey-2;
   padding:20px;
   margin-bottom: 40px;
-  height: 270px;
-  max-height: 270px;
   position: relative;
+  min-height:200px;
   h2,h3 {
     text-transform: uppercase;
     font-weight: 600;


### PR DESCRIPTION
A few things to note here:
1. We can't use sprites for images that need to responsive, I've had to revert to pngs. One option we have is  base64 encoding them on build. The file size would go up ~10-15% but we would have 11 less requests. We don't have anything to base64 encode in the HTML right now so perhaps something for the future.
2. We can probably get rid of all the sprites CSS related to product titles.
3. I added my script to equalize bottoms back in, it was taken out as part of DEVELOPER-240 and replaced with a hard pixel height which isn't responsive at all. This was causing the overlapping. 
