### PR TITLE
DEVELOPER-357 - configured author and contributors mapping for quickstarts

### DIFF
--- a/_dcp/data/provider/jboss-developer.json
+++ b/_dcp/data/provider/jboss-developer.json
@@ -44,6 +44,7 @@
               "index_type": "contributor",
               "source_field": "author",
               "idx_search_field": ["jbossdeveloper_quickstart_author","name"],
+              "result_multiple_ignore" : true,
               "result_mapping": [
                   {
                       "idx_result_field": "code",


### PR DESCRIPTION
`author` (from full name) and `contributors` (from email) mapping configured for `jbossdeveloper_quickstart` content type. 
Persistence enabled for all jbossdeveloper content types to make DCP backend of JBoss Developer site more reliable for production use (allows rebuild of DCP search indices without data push from site build).
