### PR TITLE
Fixes DEVELOPER-207

### DIFF
--- a/_ext/product.rb
+++ b/_ext/product.rb
@@ -46,6 +46,7 @@ module JBoss
                 
                 # Store the product in the global product map
                 site.products[product.id] = product
+                page.send('featured_items=', product['featured_items'])
               end
             end
           end

--- a/_partials/developer-materials-featured.html.slim
+++ b/_partials/developer-materials-featured.html.slim
@@ -1,7 +1,10 @@
 .slider-wrapper
   .slider#slider
     .swipe-wrap
-      - for item in site.featured_items
+      - items = site.featured_items
+      - if self[:page].output_page.product && self[:page].output_page.product['featured_items']
+        - items = self[:page].output_page.product['featured_items']
+      - for item in items
         .slide
           img(src=cdn(site.base_url + '/' + item['image_url']))
           .slider-label

--- a/products/amq/_common/product.yml
+++ b/products/amq/_common/product.yml
@@ -61,4 +61,7 @@ downloads:
       source:
         size: 64mb
 upstream_projects:
-
+featured_items:
+  - image_url: /images/slider-image1.jpg
+    title: a new featured item, at the product level
+    text: Just some random featured item text


### PR DESCRIPTION
This should allow you to override the site wide featured item with a
list of featured items at the product level, as you can see in the amq
in this commit.

This addresses Pete's requirement, and allows us to have a default in
place if we need one.
