### PR TITLE
Fixes 404s (and images that exist) from QS & tutorials

### DIFF
--- a/_ext/jboss_developer.rb
+++ b/_ext/jboss_developer.rb
@@ -1,3 +1,4 @@
+require 'uri'
 require 'aweplug/helpers/cdn'
 require 'aweplug/helpers/png'
 require 'compass'
@@ -53,6 +54,32 @@ module JBoss
 
       end
 
+    end
+  end
+end
+
+# Hack for our own purposes with QuickStarts
+module Kramdown
+  module Parser
+    class QuickStartParser 
+      def add_link(el, href, title, alt_text = nil)
+        if el.type == :a
+          if href =~ /README\.md/
+            el.attr['href'] = '../index.html' + "##{URI.parse(href).fragment}"
+          elsif href =~ /CONTRIBUTING\.md/
+            el.attr['href'] = 'contributing/index.html' + "##{URI.parse(href).fragment}"
+          else
+            el.attr['href'] = href
+          end 
+        else
+          # TODO something needs to be done about images too
+          el.attr['src'] = href
+          el.attr['alt'] = alt_text
+          el.children.clear
+        end
+        el.attr['title'] = title if title
+        @tree.children << el
+      end
     end
   end
 end

--- a/_layouts/get-started-item.html.slim
+++ b/_layouts/get-started-item.html.slim
@@ -3,9 +3,10 @@ layout: base
 status: yellow
 issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
 ---
-- page.title = page.metadata[:title]
-- page.description = page.metadata[:summary]
-- page.author = page.metadata[:author]
+- if page.metadata
+  - page.title = page.metadata[:title]
+  - page.description = page.metadata[:summary]
+  - page.author = page.metadata[:author]
 
 .row
   h2.large-title Developer Materials


### PR DESCRIPTION
There are some images, from the helloworld-mbean QS which do not exist.
That issue should be pushed upstream.

You'll also need to do a rake update to retrieve the latest aweplug, which also has some of the fix.
