### PR TITLE
Fixes DEVELOPER-477 (zip -> jar)

### DIFF
--- a/_ext/product.rb
+++ b/_ext/product.rb
@@ -94,7 +94,7 @@ module JBoss
                     c << artifact
                   end
                 else
-                  artifact = OpenStruct.new
+                  artifact = OpenStruct.new(w)
                   artifact.size = asset.size
                   artifact.type ||= artifact_attr l, "type", "zip"
                   artifact.name = asset.name
@@ -136,7 +136,7 @@ module JBoss
         def artifact_attr(key, attr, default)
           if @default_download_assets.has_key?(key) && @default_download_assets[key].has_key?(attr)
             @default_download_assets[key][attr]
-          else default
+          else
             default
           end
         end

--- a/products/devstudio/_common/product.yml
+++ b/products/devstudio/_common/product.yml
@@ -35,10 +35,12 @@ downloads:
       jar_universal:
         size: 613mb
         name: Jar (Universal Binary with EAP)
+        type: jar
       standalone_universal:
         artifacts:
           standalone_jar:
             size: 487mb
+            type: jar
           standalone_zip_central:
             size: 410mb
           standalone_zip_update:


### PR DESCRIPTION
Paul, please check to see what is in the download manager. It appears to
be .zip. If it is .zip, do we need to rename it or keep things how they
are currently?
