### PR TITLE
Fixing DEVELOPER-443 (timo links in new tabs)

### DIFF
--- a/_ext/mktg_ops.rb
+++ b/_ext/mktg_ops.rb
@@ -140,7 +140,7 @@ module JBoss::Developer::MktgOps
                 :type => 'external_link', 
                 :title => a['title'] 
               })
-              a['onclick'] ||= "" << "app.mktg_ops.track(this);return false;"
+              a['onclick'] ||= "" << "app.mktg_ops.track(this);return true;"
             end
           end
         end


### PR DESCRIPTION
I modified the transformer to return true instead false for links. This
will allow the basic link functionality to continue, yet still allow for
our tracking.
