### PR TITLE
shortening clear button for mobile

### DIFF
--- a/_partials/developer-materials-filters.html.slim
+++ b/_partials/developer-materials-filters.html.slim
@@ -1,6 +1,6 @@
 h4.filter-toggle
   | Filters
-  a.filters-clear(href="#") Clear All Filters
+  a.filters-clear(href="#") Clear All
 button.filters-apply.filter-toggle Apply
 form.dev-mat-filters(method="GET" action="")
   .filter-block


### PR DESCRIPTION
The button was overlapping on some smaller devices. 
