### PR TITLE
Home page buzz fixes

### DIFF
--- a/_partials/mini_buzz_template.html.slim
+++ b/_partials/mini_buzz_template.html.slim
@@ -1,10 +1,10 @@
 .large-12.column
   .update.pinned.updatemobile
     .update-meta
-      a.update-timestamp href="#" <!=updatedDate!>
+      a.update-timestamp href="<!=sys_url_view!>" <!=updatedDate!>
       a.update-source href="<!=sys_url_view!>"
         /i.fa.fa-twitter
-        <!=authorName!> said:
+        <!=authorSaid!>
     .update-body
       p
         / img.avatar src=""

--- a/javascripts/scripts.js
+++ b/javascripts/scripts.js
@@ -447,10 +447,10 @@ app.buzz = {
           var d = hits[i].fields;
           // This regex will parse an email like "John Smith <john.smith@acme.com>", giving you two matches "John Smith" and "john.smith@acme.corp"
           var pat = /(?:([^"]+))? <?(.*?@[^>,]+)>?,? ?/g;
-          d.authorName = "Unknown";
+          d.authorSaid = " ";
           d.authorMail = "";
           while (m = pat.exec(d.sys_contributors)) {
-            d.authorName = m[1];
+            d.authorSaid = m[1] + " said:";
             d.authorMail = m[2];
           }
           d.updatedDate = jQuery.timeago(new Date(d.sys_updated));

--- a/stylesheets/_buzz.scss
+++ b/stylesheets/_buzz.scss
@@ -170,3 +170,6 @@ h4.buzz-message.divider {
     }
   }
 
+.mini-buzz-container > div:nth-child(odd) {
+  clear: left;
+}

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -496,6 +496,8 @@ i[class*=fa].invert {
   }
   .update-meta {
     margin-bottom: 20px;
+    width: 100%;
+    float: left;
     .share-this {
       padding: 0;
       p {


### PR DESCRIPTION
When there is no author available via the DCP, we now show nothing rather than "Unknown Said:" 

A few other small fixes:
1. CSS grid clear as there is a chance that an update is longer than the one beside it.
2. Link timestamp to blog post
