### PR TITLE
Firefox 10 Fixes

### DIFF
--- a/javascripts/books.js
+++ b/javascripts/books.js
@@ -60,9 +60,6 @@ app.books = {
             } else if (ids[1].type === "ISBN_13") {
               bookItemsHash[ids[1].identifier] = books.items[i];
               books.items[i].volumeInfo.isbn = ids[1].identifier;
-            } else {
-              console.log('can not find ISBN_13');
-              console.log(books.items[i]);
             }
           }
 
@@ -75,7 +72,6 @@ app.books = {
                 bookItems.push(bookItemsHash[key]);
               }
             } 
-            console.log(bookItems);
 
             // Make sure all the books are sorted by desc date
             bookItems.sort(function(a,b) {

--- a/javascripts/dcp.js
+++ b/javascripts/dcp.js
@@ -20,6 +20,7 @@ app.dcp.resolveContributorsForBlock = function( documentType, documentId, block,
   
   app.dcp.currentRequest = $.ajax({
     url : app.dcp.url.content + "/" + documentType + "/" + documentId,
+    dataType: 'json',
     beforeSend : function() {
       // check if there is a previous ajax request to abort
       if(app.dcp.currentRequest && app.dcp.currentRequest.readyState != 4) {

--- a/javascripts/developer-materials.js
+++ b/javascripts/developer-materials.js
@@ -290,6 +290,7 @@ app.dm = {
     $("ul.results").addClass('loading');
 
     app.dm.currentRequest = $.ajax({
+      dataType: 'json',
       url : app.dcp.url.search,
       data : {
         "field"  : ["sys_author", "contributors", "duration", "github_repo_url", "level", "sys_contributors",  "sys_created", "sys_description", "sys_title", "sys_url_view", "thumbnail", "sys_type", "sys_rating_num", "sys_rating_avg"],

--- a/javascripts/projects.js
+++ b/javascripts/projects.js
@@ -55,6 +55,7 @@ app.project = {
 
     $.ajax({
       url : app.dcp.url.search,
+      dataType: 'json',
       data : request_data
     }).done(function(data){
       var hits = data.hits.hits; // first one for testing

--- a/javascripts/scripts.js
+++ b/javascripts/scripts.js
@@ -427,6 +427,7 @@ app.buzz = {
     
     $.ajax({
         url : app.dcp.url.search,
+        dataType: 'json',
         data : {
           "field"  : ["sys_url_view", "sys_title", "sys_contributors", "sys_description", "sys_updated"],
           "query" : query,

--- a/javascripts/search.js
+++ b/javascripts/search.js
@@ -16,6 +16,7 @@ app.search = {
     // perform ajax request
     $.ajax({
       url : app.dcp.url.search,
+      dataType: 'json',
       data : {
         "field"  : ["sys_title", "sys_url_view"],
         "type" : "jbossdeveloper_website",


### PR DESCRIPTION
Looks like the server response wasn't `application/json` so we need to explicitly say it is json. Fixes the issue some users were having in 2 year old firefox 10. 
