### PR TITLE
Buzz Page fixes

### DIFF
--- a/buzz.html.slim
+++ b/buzz.html.slim
@@ -37,6 +37,4 @@ description: JBoss Developer is an open and active community, with updates happe
         li: a(data-filter="google-plus")
           i.icon-google-plus
 
-  .large-24.columns.buzz-container.loading
-    .buzz-items
-
+  .large-24.columns.buzz-container.buzz-loading

--- a/javascripts/scripts.js
+++ b/javascripts/scripts.js
@@ -183,9 +183,6 @@ app.init = function() {
   if($container.length) {
 
     $(window).load(function() {
-      $container.isotope({
-        itemSelector: '.buzz-item'
-      });
 
       // Filtering
       /*$('.sort-icons a').click(function(){
@@ -466,6 +463,14 @@ app.buzz = {
         html = "Sorry, no results to display.";
       }
       container.html(html);
+
+      // run isotope only once they have been embedded into the dom AND images are loaded
+      $(window).load(function() {
+        container.isotope({
+          itemSelector: '.buzz-item'
+        });
+      });
+
       container.removeClass('buzz-loading');
       $('.share-this').on('click mouseover', function() {
         Socialite.load($(this)[0]);


### PR DESCRIPTION
The isotope plugin was previously being called once images were loaded on the page. 

Since it was swtiched over to the DCP, it was sometimes being called before the DCP had returned items. 

So, now we wait for both the DCP to return items as well as the images to load. 
