### PR TITLE
Fixes DEVELOPER-711

### DIFF
--- a/stylesheets/_developer-materials.scss
+++ b/stylesheets/_developer-materials.scss
@@ -12,6 +12,7 @@ ul.results {
   margin-top: 20px;
   &.loading {
     background:cdn("../images/icons/ajax-loader.gif") center 80px no-repeat;
+    min-height:250px;
     li.material {
       visibility: hidden;
     }

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -1676,6 +1676,12 @@ table.demos {
   border-radius: 10px;
 }
 
+.loading, .buzz-loading {
+  .dcp-error-message {
+    display: none;
+  }
+}
+
 // hack for asciidoctor and older font-awesome content when asciidoctor #955 is merged this can go away
 td.icon {
   vertical-align: middle;


### PR DESCRIPTION
When we type, we sometimes kill in-process ajax requests to start the next one. This triggers an error, so this fix hides error message when killing/creating new ajax request.
