### PR TITLE
Fixed path to sprite-project-icons-all.png

### DIFF
--- a/stylesheets/global.scss
+++ b/stylesheets/global.scss
@@ -209,7 +209,7 @@ with these settings:
   Class Prefix (optional): nothing
 */
 .project-icon-med {
-  background: url(../../images/icons/sprite-project-icons-all.png) no-repeat top left;
+  background: url(//static.jboss.org/images/sprite-project-icons-all.png) no-repeat top left;
   float:left;
   margin:-1px 4px 0 0;
   display:block;
@@ -297,7 +297,7 @@ with these settings:
 */
 
 .jira-icon {
-  background: url(../../images/common/jira-icons-sprite.png) no-repeat top left;
+  background: url(//static.jboss.org/images/jira-icons-sprite.png) no-repeat top left;
   width: 16px;
   height: 16px;
   display: inline-block;


### PR DESCRIPTION
It now lives on http://static.jboss.org/images/sprite-project-icons-all.png
