### PR TITLE
Updating gitignore to ignore highlightjs magula.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ links.html
 .project
 images/sprites
 stylesheets/global.css
+stylesheets/magula.css


### PR DESCRIPTION
This CSS file always creeps it way into my commits when it should not. Updating the gitignore file
