### PR TITLE
OS filters / selector widget. Fixes DEVELOPER-193

### DIFF
--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -172,6 +172,7 @@ body(class="#{template}")
     script src="#{site.base_url}/#{site.context_url}/javascripts/projects.js"
     script src="#{site.base_url}/#{site.context_url}/javascripts/books.js"
     script src="#{site.base_url}/#{site.context_url}/javascripts/search.js"
+    script src="#{site.base_url}/#{site.context_url}/javascripts/os-filter.js"
 
   / Disabled, pending reimplementation of Share This functionality
   /script src="http://platform.linkedin.com/in.js"

--- a/_layouts/product-get-started.html.slim
+++ b/_layouts/product-get-started.html.slim
@@ -53,7 +53,8 @@ ol
         | .
 
 h3.divider#configure-maven Configure Apache&trade; Maven
- 
+
+= partial "os-selector.html.slim"
 = partial "maven_repository_instructions.adoc"
 
 - if page.product.featured_items

--- a/_partials/os-selector.html.slim
+++ b/_partials/os-selector.html.slim
@@ -1,0 +1,13 @@
+ul.os-selector.hidden
+  input(type="radio" id="mac" value="mac" name="os")
+  label(for="mac")
+    i.fa.fa-apple
+    | OSX
+  input(type="radio" id="windows" value="windows" name="os")
+  label(for="windows")
+    i.fa.fa-windows
+    | Windows
+  input(type="radio" id="linux" value="linux" name="os")
+  label(for="linux")
+    i.fa.fa-linux
+    | Linux

--- a/javascripts/os-filter.js
+++ b/javascripts/os-filter.js
@@ -1,0 +1,71 @@
+app.os = {
+  process : function() {
+    $('dt').each(function(){
+      var el = $(this);
+      var text = el.text();
+      var mac = new RegExp("\\bos\\ ?x\\b|\\bmac\\b","gi"); // osx mac macintosh OS X  OSX..
+      var windows = new RegExp("windows","gi"); // windows Windows...
+      var linux = new RegExp("\\blinux\\b|\\bunix\\b","gi") // Linux, Unix...
+
+      if(text.match(mac)) {
+        el.addClass('os-mac');
+        el.next().addClass('os-mac');
+      }
+
+      if(text.match(windows)) {
+        el.addClass('os-windows');
+        el.next().addClass('os-windows');
+      }
+
+      if(text.match(linux)){
+        el.addClass('os-linux');
+        el.next().addClass('os-linux');
+      }
+
+      if($('.os-mac, .os-linux, .os-windows').length) {
+        $('ul.os-selector').removeClass('hidden');
+      }
+
+      app.os.bind();
+
+    });
+  },
+  detectOs : function() {
+    if(navigator.platform.toUpperCase().indexOf('MAC')!==-1) {
+      return "mac";
+    }
+    if(navigator.platform.toUpperCase().indexOf('WIN')!==-1) {
+      return "windows";
+    }
+    if(navigator.platform.toUpperCase().indexOf('LINUX')!==-1 || navigator.appVersion.indexOf("X11")!==-1) {
+      return "linux";
+    }
+    else {
+      return "other";
+    }
+  },
+  bind : function() {
+    
+    $('input[name="os"]').on('change',function() {
+      var val = $(this).val();
+      $('.os-mac, .os-windows, .os-linux').hide();
+      $('dd.os-'+val).show();
+    });
+
+    var os = app.os.detectOs();
+
+    // if we cannot find the OS or we are on mobile, set the default
+    (os === "other" ? "linux" : os);
+
+    $('input#'+os).trigger('click').trigger('change');
+
+  }
+};
+
+$(function() {
+
+  if ($('dt').length) {
+    app.os.process();
+  }
+
+});

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -1699,3 +1699,41 @@ td.content {
   padding: inherit;
   margin: inherit;
 }
+
+// Operating System Selector 
+ul.os-selector {
+  margin: 0;
+  display: inline-block;
+  border:1px solid $grey-3;
+  border-radius: $global-radius;
+  margin-bottom: 20px;
+  overflow: hidden;
+  &.hidden {
+    display: none;
+  }
+  input {
+    display: none;
+    &:checked + label {
+      background:$dark-blue;
+      color:white;
+      border-color:darken($dark-blue,5%);
+    }
+  }
+  label {
+    display: inline-block;
+    padding: 10px;
+    margin: 0;
+    border-right:1px solid $grey-3;
+    &:last-child {
+      border-right: 0;
+    }
+    &:hover {
+      background:$dark-blue;
+      color:white;
+      border-color:darken($dark-blue,5%);
+    }
+    i.fa {
+      margin-right: 10px;
+    }
+  }
+}


### PR DESCRIPTION
Our installation guides are very consistent using DT an DD elements to give separate instructions for 

Rather than have the author wrap everything in a div, we can extract the information from the title having the words osx/mac/linux/windows in them.

![ss 2014-07-01 at 2 47 28 pm](https://cloud.githubusercontent.com/assets/176013/3447746/eec6320e-0150-11e4-8597-1fba4d539660.png)
