### PR TITLE
fixed the developer materials bookmarking links. DEVELOPER-940

### DIFF
--- a/javascripts/developer-materials.js
+++ b/javascripts/developer-materials.js
@@ -568,10 +568,6 @@ app.dm = {
     app.dm.clearFilters($(this));
   });
 
-  if ($('form.dev-mat-filters').length) {
-    app.dm.devMatFilter();
-  }
-
   // slide toggle on mobile
   $('.filter-block h5').on('click',function() {
     if(window.innerWidth <= 768) {


### PR DESCRIPTION
we don't need to call this on command, as the page hash checker does it for us. 
