### PR TITLE
DEVELOPER-946 fixing bookmarkable filters with spaces in the value

### DIFF
--- a/javascripts/developer-materials.js
+++ b/javascripts/developer-materials.js
@@ -59,9 +59,9 @@ app.dm = {
             }
             break;
           case "topics" :
-            var valArray = formValue.split(" ");
+            var valArray = formValue.split(",");
             $.each(valArray, function(idx, value){
-              $('[name="filter-topic[]"][value=' + value + ']').attr('selected', true).attr('checked', true).trigger('change');
+              $('[name="filter-topic[]"][value="' + value + '"]').attr('selected', true).attr('checked', true).trigger('change');
             });
             break;
           case "formats":


### PR DESCRIPTION
When more topics were introduced, some of them had spaces in the names and it was switched to a comma. 
