### PR TITLE
Enable metrics for staging

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -64,7 +64,7 @@ profiles:
     <<: *profile
     dcp_base_protocol_relative_url: //dcpbeta-searchisko.rhcloud.com/
     dcp_base_url: http://dcpbeta-searchisko.rhcloud.com/
-    metrics: false
+    metrics: true
     deploy:
       <<: *deploy
       path: /stg_htdocs/www-stg


### PR DESCRIPTION
GTM can now route all staging metrics to our staging bucket so we should enable metrics in staging.
