### PR TITLE
Update TicketMonster PDF link to 2.6

### DIFF
--- a/_layouts/ticket-monster.html.slim
+++ b/_layouts/ticket-monster.html.slim
@@ -34,7 +34,7 @@ br
     = page._outline
 
   .large-16.columns
-    a.right.button(href="http://docs.jboss.org/jdf/2.5/ticket-monster-2.5.0.Final.pdf" target="_blank") Download the Instructions
+    a.right.button(href="http://docs.jboss.org/jbossdeveloper/2.6/ticket-monster-2.6.0.Final.pdf" target="_blank") Download the Instructions
     h3#follow-along Follow along with video
 
     .flex-video.large.24


### PR DESCRIPTION
The site now references the PDF located at http://docs.jboss.org/jbossdeveloper/2.6/ticket-monster-2.6.0.Final.pdf
