### PR TITLE
Revert "Addresses DEVELOPER-1028 (duplicate descriptions)"

### DIFF
--- a/_layouts/get-started-item.html.slim
+++ b/_layouts/get-started-item.html.slim
@@ -6,7 +6,7 @@ issues: [DEVELOPER-179, DEVELOPER-77, DEVELOPER-202]
 ---
 - if page.metadata
   - page.title = page.metadata[:title]
-  - page.description = (page.metadata[:title] || '') + ': ' + page.metadata[:summary]
+  - page.description = page.metadata[:summary]
   - page.author = page.metadata[:author]
   - if page.metadata[:product] && site[:products][page.metadata[:product]]
     - page.product = site[:products][page.metadata[:product]]


### PR DESCRIPTION
After thinking this through, it's better to try addressing this at source and enforce unique and correctly sized descriptions.

Reverts jboss-developer/www.jboss.org#597
