### PR TITLE
Updating Ticket Monster download link && docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,6 +188,8 @@ EAP quickstarts are used here as an example:
 
 9. Go to GitHub and raise a PR for your change.
 
+#### Updating Ticket Monster download version
+If Ticket Monster has released a new version, the download link in `ticket-monster.adoc` needs to be manually updated as well. Follow the above process for creating a git branch and assigning a JIRA ticket. Open the `ticket-monster.adoc` file and find the correct `DOWNLOAD IT` link, retreive the new link from GitHub and modify the document. Then follow the above instructions for adding the change, pushing the branch and creating a new pull request.  
 
 ## How to Make Changes to the Product Pages
 The product pages are those linked from www.jboss.org/products.

--- a/ticket-monster.adoc
+++ b/ticket-monster.adoc
@@ -24,7 +24,7 @@ pass:[<span><i class="fa fa-book fa-9x fa-fw"></i></span>]
 
 == Downloadit
 
-=== https://github.com/jboss-developer/ticket-monster[DOWNLOAD IT]
+=== https://github.com/jboss-developer/ticket-monster/archive/2.6.0.Final-with-tutorials.zip[DOWNLOAD IT]
 
 Download Ticket Monster and get started with our tutorial. You can also use Ticket Monster as a base to build your own application.
 pass:[<a href="https://github.com/jboss-developer/ticket-monster" style="float:right; text-align:right;"><i class="fa fa-github">&nbsp;</i>Fork us</a>]


### PR DESCRIPTION
Both of the download links for Ticket Monster should point to the same
location now. You manually have to update the link in the asciidoc
document. I've also added instructions on how and what needs to change.
