### PR TITLE
DEVELOPER-1080 Added Data Virtualization version 6.1.0.ALPHA Jar file to dowloads

### DIFF
--- a/products/datavirt/_common/product.yml
+++ b/products/datavirt/_common/product.yml
@@ -1,6 +1,6 @@
 name: Red Hat JBoss Data Virtualization
 abbreviated_name: JBoss Data Virtualization
-current_version: 6.0.0.GA
+current_version: 6.1.0.ALPHA
 documentation_minor_version: 6
 xpaas_url: https://www.openshift.com/developers/jboss-data-virtualization
 intro_video: https://vimeo.com/91533636
@@ -25,6 +25,14 @@ guides:
         url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Virtualization/6/epub/Release_Notes/Red_Hat_JBoss_Data_Virtualization-6-Release_Notes-en-US.epub
 description: 'A data virtualization tool useful for any organization struggling to gain operational and analytical insights from data dispersed and locked up in various business units, applications, and technology silos. (formerly known as JBoss Enterprise Data Services Platform).'
 downloads:
+  6.1.0.ALPHA:
+    release_date: 2014-11-03
+    description: Improved User Interface, OpenShift Beta Cartridge, Kerberos, Audit Log in Dashboard, MongoDB, Cloudera/Impala. Apache Solr, EAP 6.3, JDG 6.2.
+    assets:
+      zip:
+        size: 290mb
+        name: Jar (Installer)
+        filename: jboss-dv-installer-6.1.0.ER2-redhat-1.jar
   6.0.0.GA:
     release_date: 2014-02-03
     description: Accesses and transforms data from one or more heterogeneous sources into logical, business-friendly data models.


### PR DESCRIPTION
I switched the current version to the ALPHA release, so it is now the displayed download.  I can switch items around if we would like to have the general release available first and the alpha release after.  

Also, I didn't see any documentation or other files available to add to the download manager yet, but I can add them as well when they become available.
