### PR TITLE
Ignoring compiled foundation CSS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ links.html
 .project
 images/sprites
 stylesheets/global.css
+stylesheets/foundation/foundation.css
+stylesheets/foundation/normalize.css
 stylesheets/magula.css
 _wraith/shots
 _wraith/sitemap_tmp.txt


### PR DESCRIPTION
When we either upgraded to foundation 5 or the new version of compass, the process gens these files. We don't want to have these files in the repo as they are generated and not source files. 
