### PR TITLE
Update link for to Github org

### DIFF
--- a/docker/index.html.slim
+++ b/docker/index.html.slim
@@ -17,7 +17,7 @@ p
 
     === JBoss projects and Docker
 
-    We publish our images under the official https://hub.docker.com/u/jboss/[jboss organization]. Every image is built from Dockerfiles available in our https://github.com/jboss/dockerfiles[GitHub repository]. To keep them up to date we have http://docs.docker.com/docker-hub/builds/[automated builds] that track the source and rebuild images (only) if necessary. Additionally, images are linked to each other: If an image we're base on is modified, we rebuild our image to provide you the fresh image that you deserve.
+    We publish our images under the official https://hub.docker.com/u/jboss/[jboss organization]. Every image is built from Dockerfiles available from the repositories in our https://github.com/jboss-dockerfiles[GitHub organization]. To keep them up to date we have http://docs.docker.com/docker-hub/builds/[automated builds] that track the source and rebuild images (only) if necessary. Additionally, images are linked to each other: If an image we're base on is modified, we rebuild our image to provide you the fresh image that you deserve.
 
 .row
   .large-6.columns


### PR DESCRIPTION
Link to new jboss-dockerfiles organization (vs repo).  Need to update links dockerfile/README on individual Docker images as well (i.e. WildFly links are broken, still pointing to repo folder vs separated repo in org.
