### PR TITLE
DEVELOPER-1104 Added in JDG 6.4 Beta to the available downloads - Release notes currently not working

### DIFF
--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -73,6 +73,7 @@ downloads:
       source:
         size: 38mb
       release_notes:
+        url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.4/html/6.4.0_Beta_Release_Notes/index.html
   6.3.0.GA:
     release_date: 2014-07-21
     description: An in-memory distributed database, Red Hat JBoss Data Grid provides fast access to data and elastic scalability for large data volumes.


### PR DESCRIPTION
Also, to update the 'Green button', don't we need to change the default download?
