### PR TITLE
DEVELOPER-1126 Google Plus contributor links are broken

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/awestruct/aweplug.git
-  revision: fbf64fb6b72734c73357975cbae546b993d75edd
+  revision: f9644c59265bf8547d1b75ae153f1c863b7f338b  
   specs:
     aweplug (1.0.0.a24)
       curb (~> 0.8.5)


### PR DESCRIPTION
Depends on https://github.com/awestruct/aweplug/pull/79
