### PR TITLE
Fixes DEVELOPER-1109 and fixes DEVELOPER-1016

### DIFF
--- a/_ext/jboss_developer.rb
+++ b/_ext/jboss_developer.rb
@@ -206,10 +206,12 @@ module Kramdown
     class QuickStartParser 
       def add_link(el, href, title, alt_text = nil)
         if el.type == :a
-          if href =~ /README\.md/
-            el.attr['href'] = '../index.html' + "##{URI.parse(href).fragment}"
+          if href =~ /^http[s]?:/
+            el.attr['href'] = href # If the link is absolute let it go
+          elsif href =~ /README\.md/
+            el.attr['href'] = href.gsub('README.md', 'index.html')
           elsif href =~ /CONTRIBUTING\.md/
-            el.attr['href'] = 'contributing/index.html' + "##{URI.parse(href).fragment}"
+            el.attr['href'] = href.gsub('CONTRIBUTING.md', 'contributing/index.html')
           else
             el.attr['href'] = href
           end 


### PR DESCRIPTION
DEVELOPER-1109 deals with the contribution guide, which should be
rendering correctly now, We're not touching absolute links from
kramdown.

DEVELOPER-1016 is about quickstarts in JDG (or any other place) that
links directly to the README.md files using relative links. Now we're
simply doing a gsub to replace "README.md" with "index.html". The rest
of the link should work correctly.