### PR TITLE
Setting the thread size correctly

### DIFF
--- a/_ext/common_dir.rb
+++ b/_ext/common_dir.rb
@@ -49,7 +49,7 @@ module JBoss
 
 
             # Iterate over all pages
-            Parallel.each(site.pages, in_threads: 40) do |page|
+            Parallel.each(site.pages, in_threads: (site.build_threads || 0)) do |page|
               # Check if there is a _common directory in the hierarchy of directories above this one
               dir_map.each do |parent, vars| 
                 if page.source_path =~ /^#{site.dir}\/#{parent}/

--- a/_ext/connectors.rb
+++ b/_ext/connectors.rb
@@ -12,7 +12,7 @@ module JBoss
       def execute site
         searchisko = Aweplug::Helpers::Searchisko.default site, 0
 
-        Parallel.each(site.fuse_connectors, in_threads: 5) do |(id, data)|
+        Parallel.each(site.fuse_connectors, in_threads: (site.build_threads || 0)) do |(id, data)|
 
           searchisko_hash = data.collect { |(key, value)|
 

--- a/_ext/stacks.rb
+++ b/_ext/stacks.rb
@@ -32,7 +32,7 @@ module JBoss::Developer::Extensions
                                                      :cache => site.cache,
                                                      :logger => site.log_faraday,
                                                      :searchisko_warnings => site.searchisko_warnings})
-      Parallel.each(yml['availableRuntimes'], in_threads: 20) do |runtime|
+      Parallel.each(yml['availableRuntimes'], in_threads: (site.build_threads || 0)) do |runtime|
         # WARNING Hacks below
         case runtime['labels']['runtime-type']
         when 'JPP'


### PR DESCRIPTION
The rest of the build uses this same pattern to allow us to control the size
of the threads being used. These should follow the same pattern.
