### PR TITLE
Fixes DEVELOPER-1186, grey background in event

### DIFF
--- a/stylesheets/_events.scss
+++ b/stylesheets/_events.scss
@@ -13,6 +13,7 @@
       background-clip: content-box;
       background-origin:content-box;
       text-indent: 20px;
+      background-color: white;
       &:first-child {
         margin-right:3px;
       }


### PR DESCRIPTION
Simple fix, the grey background was cascading from readonly inputs.