### PR TITLE
Fixes DEVELOPER-1192 indentation on get-started

### DIFF
--- a/_layouts/product-get-started.html.slim
+++ b/_layouts/product-get-started.html.slim
@@ -39,6 +39,7 @@ ol
         p: code
           | unzip #{page.product.default_download_artifact.filename}
     - if page._extra_installation_instructions
+      .extra-installation-instructions
         = page._extra_installation_instructions
   - else 
     li

--- a/stylesheets/_get-started.scss
+++ b/stylesheets/_get-started.scss
@@ -29,6 +29,12 @@
   }
 }
 
+.extra-installation-instructions {
+  & ol {
+    margin-left: 0;
+  }
+}
+
 .get-started-content {
   padding-top: 15px;
   text-align: center;


### PR DESCRIPTION
Probably the best we can do is this small style hack. What was happening
is that you get on ol:li inside of another ol:li section which really
messes up the formatting. A correct fix would be to end one ol and start
another, but I don't see a way of doing this easily without refactoring
the layout extensively. I did try some other solutions, but nothing
worked the way I expected it to.