### PR TITLE
Elasticsearch mapping for jbossdeveloper_example type is incorrect.

### DIFF
--- a/_dcp/mappings/data_jbossdeveloper_example/jbossdeveloper_example.json
+++ b/_dcp/mappings/data_jbossdeveloper_example/jbossdeveloper_example.json
@@ -1,5 +1,5 @@
 {
-  "jbossdeveloper_quickstart": {
+  "jbossdeveloper_example": {
     "properties": {
       "tags": {
         "type": "string",


### PR DESCRIPTION
Closes #DEVELOPER-1208