### PR TITLE
WINDUP-180: Fix JIRA link for WINDUP issues

### DIFF
--- a/_config/blinkr.yaml
+++ b/_config/blinkr.yaml
@@ -48,7 +48,7 @@ skips:
     # JDF-773
   - !ruby/regexp /^https:\/\/docs.jboss.org\/author\/display\/PLINK\/Unsolicted\+Responses+/
     # WINDUP-180
-  - !ruby/regexp /^http:\/\/www-stg.jboss.org\/pr\/\d{3}\/build\/\d{4}\/projects\/issues.jboss.org\/browse\/WINDUP+/
+  - !ruby/regexp /^http:\/\/issues.jboss.org\/browse\/WINDUP+/
     # JDF-791
   - !ruby/regexp /^https:\/\/devstudio.jboss.com\/central\/install\?connectors=org.jboss.tools.aerogear.hybrid+/
     # JDF-770


### PR DESCRIPTION
This change is to fix https://issues.jboss.org/browse/WINDUP-180
I can not build this, so I was not able to test the fix. Please review it carefully!
The current link to Windup issues resolves to: http://www.jboss.org/projects/issues.jboss.org/browse/WINDUP
It should resolve to: http://issues.jboss.org/browse/