### PR TITLE
Persist jbossdeveloper_website content type

### DIFF
--- a/_dcp/data/provider/jboss-developer.json
+++ b/_dcp/data/provider/jboss-developer.json
@@ -426,6 +426,7 @@
     "jbossdeveloper_website": {
       "description":"JBoss Developer website pages",
       "sys_type":"webpage",
+      "persist": true,
       "input_preprocessors": [
         { 
           "name"     : "Projects mapper",


### PR DESCRIPTION
Persisting this content type will help in testing when indices are created from DB snapshot.