### PR TITLE
DEVELOPER-1284 Fixed width of images in get-started product pages

### DIFF
--- a/products/fuse/overview.adoc
+++ b/products/fuse/overview.adoc
@@ -46,7 +46,7 @@ Connect to external applications with connectors for JDBC, FTP/SFTP, HTTP/HTTPS,
 
 JBoss Fuse combines several technologies like core Enterprise Service Bus capabilities (based on Apache Camel, Apache CXF, Apache ActiveMQ), Apache Karaf and Fabric8 in a single integrated distribution.
 
-image::images/products/fuse/Fuse_Builtfromdiagram_02.png[]
+image::#{cdn(site.base_url + '/images/products/fuse/Fuse_Builtfromdiagram_02.png')}[]
 
 [colls="3,1",role="split-50"]
 |====

--- a/stylesheets/app.scss
+++ b/stylesheets/app.scss
@@ -959,8 +959,11 @@ body.fullbleed {
       p {
         margin:0;
       }
-
     }
+  }
+  // Keeps images from overflowing outside of their container
+  .imageblock > .content{
+    margin: auto 0;
   }
 }
 


### PR DESCRIPTION
and fixed the broken link for an image in Fuse overview product page