### PR TITLE
DEVELOPER-1259 Fixed the documentation links to portal

### DIFF
--- a/products/portal/_common/product.yml
+++ b/products/portal/_common/product.yml
@@ -6,7 +6,6 @@ youtube_album: http://www.youtube.com/playlist?list=PLcrLvMVKO0b2woVHNeCILbZ6WjD
 guides:
   Release_Notes:
   Administration_and_Configuration_Guide:
-  Development_Guide:
   Installation_Guide:
   Migration_Guide:
   User_Guide:


### PR DESCRIPTION
This will break if the once updated to 6.2; however, it is easy to remove this.