### PR TITLE
Fixes DEVEOLPER-1376 (Fixing the build locally)

### DIFF
--- a/_config/site.yml
+++ b/_config/site.yml
@@ -53,6 +53,7 @@ profiles:
     metrics: false
     authenticate_google_books_api: false
     build_threads: 0
+    cache_type: :local
   
   development_cdn: 
     <<: *development


### PR DESCRIPTION
@Dantheman720 I got lucky when I tried to build this and just happened to find the problem the first time so I figured I'd just go ahead and fix it.

The local build was trying to use the JDG cache without any info about
where it is, so you ended up doing multiple hits to the cache which
would error out then you'd have to do the full request.

I'm not sure when this changed, but things should be back to normal.