### PR TITLE
Updating aweplug to latest master

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/awestruct/aweplug.git
-  revision: a2822b455ec3fcd03cd06505a0e05e5aac8ddafa
+  revision: f4dd939f5a17d1946cebe5339411c411a8f483e3
   specs:
     aweplug (1.0.0.a24)
       curb (~> 0.8.5)
@@ -86,12 +86,12 @@ GEM
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
-    ethon (0.7.4)
+    ethon (0.8.0)
       ffi (>= 1.3.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
     extlib (0.9.16)
-    faraday (0.9.1)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
@@ -134,7 +134,7 @@ GEM
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     image_size (1.4.1)
-    iso8601 (0.8.6)
+    iso8601 (0.8.7)
     json (1.8.3)
     jwt (1.5.1)
     kramdown (1.0.2)
@@ -150,7 +150,7 @@ GEM
     method_source (0.8.2)
     mime-types (2.1)
     mini_portile (0.6.2)
-    minitest (5.8.0)
+    minitest (5.8.1)
     multi_json (1.11.2)
     multipart-post (2.0.0)
     nenv (0.2.0)
@@ -161,7 +161,7 @@ GEM
       shellany (~> 0.0)
     oauth (0.3.6)
       ruby-hmac (>= 0.3.1)
-    octokit (4.1.0)
+    octokit (4.1.1)
       sawyer (~> 0.6.0, >= 0.5.3)
     oga (0.3.4)
       ast
@@ -186,7 +186,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (2.0.2)
+    retriable (2.1.0)
     robotex (1.0.0)
     ruby-duration (3.2.1)
       activesupport (>= 3.0.0)
@@ -219,8 +219,8 @@ GEM
     tilt (2.0.1)
     timers (4.0.4)
       hitimes
-    typhoeus (0.7.3)
-      ethon (>= 0.7.4)
+    typhoeus (0.8.0)
+      ethon (>= 0.8.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.0.1)
@@ -275,3 +275,6 @@ DEPENDENCIES
   therubyracer
   uglifier (~> 2.0.1)
   wraith (~> 1.3.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
This updates to use the raise_error instead of the StatusLogger