### PR TITLE
DEVELOPER-1426 - Fixed the URL issue with the quickstart rendering

### DIFF
--- a/javascripts/developer-materials.angular.js
+++ b/javascripts/developer-materials.angular.js
@@ -187,7 +187,7 @@ dcp.filter('urlFix', function() {
       return str;
     }
     else if(str.contains("developers.redhat.com")){
-      return str.replace("developers.redhat.com", '#{site.base_url}/')
+      return str.replace("developers.redhat.com", "jboss.org")
     }
     else {
       return str.replace(/^http(s)?:\/\/(\w|\.|\-|:)*(\/pr\/\d+\/build\/\d+\/)?/, '#{site.base_url}/');


### PR DESCRIPTION
Note:  This is difficult to test locally because of the domain differences; however, I was able to hack the javascript to get it to render properly.  This also likely won't show up on any blinkr reports because of the domain differences.

If we change line 193 to point to "jboss.org" instead of the base_url, all of the developer materials should show up in local and staging builds.  Maybe we could set this variable in a config file to avoid hardcoding?