### PR TITLE
DEVELOPER-1442 - Added BRMS and BPM Suite Downloads to the page

### DIFF
--- a/products/bpmsuite/_common/product.yml
+++ b/products/bpmsuite/_common/product.yml
@@ -1,8 +1,8 @@
 name: Red Hat JBoss BPM Suite
 abbreviated_name: JBoss BPM Suite
 has_installer: true
-current_version: 6.1.0.GA
-documentation_minor_version: 6.1
+current_version: 6.2.0.GA
+documentation_minor_version: 6.2
 xpaas_url: https://www.openshift.com/developers/jboss-bpms
 intro_video: https://vimeo.com/142883902
 vimeo_album: http://vimeo.com/album/2982446
@@ -27,6 +27,29 @@ default_download_artifact_type: installer
 description: 'A business process and decision management platform that provides business users and developers with powerful and intuitive tools to capture business processes, policies and rules.  Combined with reporting and simulation, this platform allows agile modification of systems in response to business needs.'
 downloads:
   # 6.0.2 is an exclusion to the "no micros through $0 dev program
+  6.2.0.GA:
+    description: Minor release in the JBoss BPM Suite 6.x series.
+    tag_line: One integrated User Interface - Business Central that is central to all business activities, an integrated modeling environment for business users. Includes process modeling, data modeling, user forms design and rules authoring, process simulation to help business users understand the likely behaviors, costs, etc. of business processes before they are deployed in production, business Activity Monitoring (BAM) tools such as Dashboards, Reports, KPI indicators etc. that provide business managers with a complete picture of the state and performance of automated processes and a BPM runtime platform that will reliably handle a wide range of workloads, from small departments to global enterprises.
+    release_date: 2015-12-07
+    assets:
+      installer:
+        size: 277mb
+      zip:
+        artifacts:
+          deployable:
+            size: 206mb
+      zip_planner:
+        size: 94mb
+        name: Optaplanner
+      example:
+        size: 4mb
+        name: Quickstarts
+      zip_supplemental:
+        size: 63mb
+        name: Supplemental Tools
+      release_notes:
+      source:
+        size: 152mb
   6.1.0.GA:
     description: Minor release in the JBoss BPM Suite 6.x series
     tag_line: Critical enterprise features such as better integration with Camel, highly customizable business central that enables partners and customers to extend the platform, productivity enhancement features, collaborative user interface and enhanced stability of the platform. Includes full support for Business Resource Planner that offers ability to build resource optimized solutions.

--- a/products/brms/_common/product.yml
+++ b/products/brms/_common/product.yml
@@ -1,8 +1,8 @@
 name: Red Hat JBoss BRMS
 abbreviated_name: JBoss BRMS
 has_installer: true
-current_version: 6.1.0.GA
-documentation_minor_version: 6.1
+current_version: 6.2.0.GA
+documentation_minor_version: 6.2
 intro_video: https://vimeo.com/95600665
 vimeo_album: http://vimeo.com/album/2982444
 youtube_album: https://www.youtube.com/playlist?list=PLf3vm0UK6HKr0DPn1NaTmB-DY5WGeMtfN
@@ -28,6 +28,29 @@ default_download_artifact_type: installer
 description: 'A rule-based programming platform built on Drools Expert, Drools Guvnor, and Drools Fusion that allows users to capture rules that can be easily modified as the business changes without impacting static applications.'
 downloads:
   # 6.0.2 is an exclusion to the "no micros through $0 dev program
+  6.2.0.GA:
+    description: Red Hat JBoss BRMS 6.0.2 is an incremental bug fix release over the 6.0.1 version.
+    tag_line: An integrated and flexible User Interface - Business Central.  One place for all authoring, analyzing, managing and testing business rules, an updated repository infrastructure that is user friendly and provides enterprise flexibility and an enhanced rules execution algorithms and language features that deliver higher performance.
+    release_date: 2015-12-07
+    assets:
+      installer:
+        size: 250mb
+      zip:
+        artifacts:
+          deployable:
+            size: 176mb
+      zip_planner:
+        size: 94mb
+        name: Optaplanner
+      example:
+        size: 4mb
+        name: Quickstarts
+      zip_supplemental:
+        size: 63mb
+        name: Supplemental Tools
+      release_notes:
+      source:
+        size: 152mb
   6.1.0.GA:
     description: Red Hat JBoss BRMS 6.0.2 is an incremental bug fix release over the 6.0.1 version.
     tag_line: Built in centralized decision server, collaborative user interface, expanded platform certifications and enhanced stability of the platform. Includes full support for Business Resource Planner that offers ability to build resource optimized solutions.


### PR DESCRIPTION
This isn't quite ready yet.  I am still a little uncertain on whether or not both products were consolidated under BRMS intentionally (see issue DEVELOPER-1422).  I commented out bpmsuite yaml for right now.   If the consolidation was intentional, I can just remove the comment tags and fix the current version under bpmsuite's yaml and we should be good to go.  Else we'll need to switch things around a bit