### PR TITLE
Updating documentation references for JDG 7.0 GA.

### DIFF
--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -1,6 +1,6 @@
 name: Red Hat JBoss Data Grid
 abbreviated_name: JBoss Data Grid
-current_version: 6.5.0.GA
+current_version: 7.0.0.GA
 intro_video: https://vimeo.com/95291413
 vimeo_album: http://vimeo.com/album/2982379
 youtube_album: https://www.youtube.com/playlist?list=PLf3vm0UK6HKqNQqGC2KitIx4eMsEVWBaQ
@@ -10,12 +10,14 @@ guides:
   API_Documentation:
     formats:
       html:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.5/html/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/7.0/html/API_Documentation/index.html
       html-single:
-        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/6.5/html-single/API_Documentation/index.html
+        url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/7.0/html-single/API_Documentation/index.html
   Developer_Guide:
+  Feature_Support_Guide:
   Getting_Started_Guide:
-  Infinispan_Query_Guide:
+  Migration_Guide:
+  Performance_Tuning_Guide:
 default_download_artifact_type: zip
 description: 'An intelligent, distributed caching solution that boosts application performance, provides greater deployment flexibility, and minimizes the overhead of standing up new applications.'
 upstream_projects:

--- a/products/datagrid/_common/product.yml
+++ b/products/datagrid/_common/product.yml
@@ -14,7 +14,7 @@ guides:
       html-single:
         url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Data_Grid/7.0/html-single/API_Documentation/index.html
   Developer_Guide:
-  Feature_Support_Guide:
+  Feature_Support_Document:
   Getting_Started_Guide:
   Migration_Guide:
   Performance_Tuning_Guide:


### PR DESCRIPTION
JDG 7.0.0 GA'd yesterday, and I have updated the references to point to the latest docs. Note that the Infinispan Query guide has been removed, while a few additional books have been added to this list.